### PR TITLE
Moving configuration to initializer and moving to v3 api.

### DIFF
--- a/lib/nytimes_bestsellers.rb
+++ b/lib/nytimes_bestsellers.rb
@@ -12,7 +12,6 @@ module Bestsellers
     #   end
     def configure(silent = false)
       yield(configuration)
-      self.sender
     end
 
     # The configuration object.

--- a/lib/nytimes_bestsellers.rb
+++ b/lib/nytimes_bestsellers.rb
@@ -3,11 +3,6 @@ require 'nytimes_bestsellers/configuration'
 
 module Bestsellers
   class << self
-
-    def new
-      @list ||= Bestsellers::List.new
-    end
-
     # Call this method to modify defaults in your initializers.
     #
     # @example

--- a/lib/nytimes_bestsellers.rb
+++ b/lib/nytimes_bestsellers.rb
@@ -1,10 +1,29 @@
 require 'nytimes_bestsellers/client'
+require 'nytimes_bestsellers/configuration'
 
 module Bestsellers
   class << self
 
     def new
       @list ||= Bestsellers::List.new
+    end
+
+    # Call this method to modify defaults in your initializers.
+    #
+    # @example
+    #   Bestsellers.configure do |config|
+    #     config.api_key = '1234567890abcdef'
+    #     config.secure  = false
+    #   end
+    def configure(silent = false)
+      yield(configuration)
+      self.sender
+    end
+
+    # The configuration object.
+    # @see Bestseller.configure
+    def configuration
+      @configuration ||= Configuration.new
     end
 
     def method_missing(method, *args, &block)

--- a/lib/nytimes_bestsellers/client.rb
+++ b/lib/nytimes_bestsellers/client.rb
@@ -1,18 +1,16 @@
 require 'json'
 require 'httparty'
-require 'nytimes_bestsellers/configuration'
 
 module Bestsellers
 
   class List
-    
-    include Bestsellers::Configuration
     include HTTParty
 
     BOOKS_URL = "http://api.nytimes.com/svc/books/v3/lists"
     BOOKS_URL
 
     def initialize
+      @api_key = Bestseller.Configuration.api_key
       reset
     end
 
@@ -35,7 +33,7 @@ module Bestsellers
         set_urlparam(url, thing, o)
       end
 
-      url << "&api-key=#{api_key}"
+      url << "&api-key=#{@api_key}"
 
       HTTParty.get(url)
     end
@@ -55,7 +53,7 @@ module Bestsellers
         set_urlparam(url, thing, o)
       end
 
-      url << "&api-key=#{api_key}"
+      url << "&api-key=#{@api_key}"
 
      HTTParty.get(url)
     end
@@ -63,7 +61,7 @@ module Bestsellers
     def bestseller_lists_overview(o = {})
       date = (Date.parse o[:date] || Date.today).strftime('%Y-%m-%e')
 
-      HTTParty.get(BOOKS_URL + "/overview?published_date=#{date}&api-key=#{api_key}")
+      HTTParty.get(BOOKS_URL + "/overview?published_date=#{date}&api-key=#{@api_key}")
     end
 
     def single_history(o = {})
@@ -76,17 +74,17 @@ module Bestsellers
         set_urlparam(url, thing, o)
       end
 
-      url << "&api-key=#{api_key}"
+      url << "&api-key=#{@api_key}"
 
       HTTParty.get(url)
     end
 
     def find_list_names
-      HTTParty.get(BOOKS_URL + "/names?api-key=#{api_key}")
+      HTTParty.get(BOOKS_URL + "/names?api-key=#{@api_key}")
     end
 
     def age_groups
-      HTTParty.get(BOOKS_URL + "/age-groups?api-key=#{api_key}")
+      HTTParty.get(BOOKS_URL + "/age-groups?api-key=#{@api_key}")
     end
 
   end

--- a/lib/nytimes_bestsellers/client.rb
+++ b/lib/nytimes_bestsellers/client.rb
@@ -9,7 +9,7 @@ module Bestsellers
     include Bestsellers::Configuration
     include HTTParty
 
-    BOOKS_URL = "http://api.nytimes.com/svc/books/v2/lists"
+    BOOKS_URL = "http://api.nytimes.com/svc/books/v3/lists"
     BOOKS_URL
 
     def initialize

--- a/lib/nytimes_bestsellers/client.rb
+++ b/lib/nytimes_bestsellers/client.rb
@@ -5,13 +5,9 @@ module Bestsellers
 
   class List
     include HTTParty
-
-    BOOKS_URL = "http://api.nytimes.com/svc/books/v3/lists"
-    BOOKS_URL
-
     def initialize
-      @api_key = Bestseller.Configuration.api_key
-      reset
+      @api_key = ::Bestsellers.configuration.api_key
+      @lists_url = ::Bestsellers.configuration.lists_url
     end
 
     def set_urlparam(url, name, options)
@@ -20,7 +16,7 @@ module Bestsellers
      end
 
     def get_list(list_name, o = {})
-      url = BOOKS_URL.clone
+      url = @lists_url.clone
 
       if o[:date]
         date = o[:date]
@@ -40,7 +36,7 @@ module Bestsellers
 
     def search_list(list_name, o = {})
 
-      url = BOOKS_URL.clone + "?list-name=#{list_name.gsub(/ /, '-')}"
+      url = @lists_url.clone + "?list-name=#{list_name.gsub(/ /, '-')}"
 
       date = if o[:date]
         Date.parse(o[:date]) 
@@ -61,12 +57,12 @@ module Bestsellers
     def bestseller_lists_overview(o = {})
       date = (Date.parse o[:date] || Date.today).strftime('%Y-%m-%e')
 
-      HTTParty.get(BOOKS_URL + "/overview?published_date=#{date}&api-key=#{@api_key}")
+      HTTParty.get(@lists_url + "/overview?published_date=#{date}&api-key=#{@api_key}")
     end
 
     def single_history(o = {})
 
-      url = BOOKS_URL.clone + "/best-sellers/history"
+      url = @lists_url.clone + "/best-sellers/history"
 
       url << "?"
 
@@ -80,11 +76,11 @@ module Bestsellers
     end
 
     def find_list_names
-      HTTParty.get(BOOKS_URL + "/names?api-key=#{@api_key}")
+      HTTParty.get(@lists_url + "/names?api-key=#{@api_key}")
     end
 
     def age_groups
-      HTTParty.get(BOOKS_URL + "/age-groups?api-key=#{@api_key}")
+      HTTParty.get(@lists_url + "/age-groups?api-key=#{@api_key}")
     end
 
   end

--- a/lib/nytimes_bestsellers/configuration.rb
+++ b/lib/nytimes_bestsellers/configuration.rb
@@ -2,8 +2,11 @@ module Bestsellers
   class Configuration
     attr_accessor :api_key
 
+    attr_accessor :lists_url
+
     def initialize
       @api_key = nil
+      @lists_url = 'http://api.nytimes.com/svc/books/v3/lists'
     end
 
     # Allows config options to be read like a hash

--- a/lib/nytimes_bestsellers/configuration.rb
+++ b/lib/nytimes_bestsellers/configuration.rb
@@ -1,15 +1,24 @@
 module Bestsellers
-  module Configuration
-    
+  class Configuration
     attr_accessor :api_key
 
-    def configure
-      yield self
+    def initialize
+      @api_key = nil
     end
 
-    def reset
-      self.api_key = nil
-      self
+    # Allows config options to be read like a hash
+    #
+    # @param [Symbol] option Key for a given attribute
+    def [](option)
+      send(option)
+    end
+ 
+    # Returns a hash of all configurable options
+    def to_hash
+      OPTIONS.inject({}) do |hash, option|
+        hash[option.to_sym] = self.send(option)
+        hash
+      end
     end
   end
 end

--- a/lib/nytimes_bestsellers/version.rb
+++ b/lib/nytimes_bestsellers/version.rb
@@ -1,3 +1,3 @@
 module Bestsellers
-  VERSION = "0.0.5"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Can also remain with v2 by having adding config/initializers/nytimes_list.rb:

``` ruby
require 'nytimes_bestsellers'
Bestsellers.configure do |config|
  config.lists_url = "http://api.nytimes.com/svc/books/v2/lists"
end
```
